### PR TITLE
Added artifact array handling.

### DIFF
--- a/src/test/java/org/kgrid/adapter/v8/JsV8AdapterTest.java
+++ b/src/test/java/org/kgrid/adapter/v8/JsV8AdapterTest.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.nio.file.Paths;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
@@ -92,6 +93,13 @@ public class JsV8AdapterTest {
             assertEquals("Error loading source", ex.getMessage());
             assertEquals("Function goodbye1 not found", ex.getCause().getMessage());
         }
+    }
+
+    @Test
+    public void worksWithListOfArtifacts() {
+
+        deploymentSpec.set("artifact", new ObjectMapper().createArrayNode().add("src/tolkien.js"));
+
     }
 
     @Test

--- a/src/test/java/org/kgrid/adapter/v8/JsV8ExampleKOTest.java
+++ b/src/test/java/org/kgrid/adapter/v8/JsV8ExampleKOTest.java
@@ -36,6 +36,16 @@ public class JsV8ExampleKOTest {
     }
 
     @Test
+    public void testSampleObjectWithArtifactList() throws IOException {
+        URI bmiKoPackageName = URI.create("artifact-list-v1.0/");
+        String bmiKoDeploymentSpecName = "deployment.yaml";
+        String bmiKoEndpointName = "/bmicalc";
+        Executor executor = getExecutor(bmiKoPackageName, bmiKoDeploymentSpecName, bmiKoEndpointName);
+        Object bmiResult = executor.execute("{\"weight\":70, \"height\":1.70}");
+        assertEquals("24.2", bmiResult);
+    }
+
+    @Test
     public void testSampleExecutiveObjectWithStringifiedInputObjects() throws IOException {
         URI helloKoPackageName = URI.create("hello-world/");
         String helloKoDeploymentSpecName = "deploymentSpec.yaml";

--- a/src/test/java/org/kgrid/adapter/v8/JsV8IntegrationTest.java
+++ b/src/test/java/org/kgrid/adapter/v8/JsV8IntegrationTest.java
@@ -39,6 +39,33 @@ public class JsV8IntegrationTest {
   }
 
   @Test
+  public void testActivatesObjectWithArrayAndGetsExecutor() throws IOException {
+    JsonNode deploymentSpec = getDeploymentSpec("artifact-list-v1.0/deployment.yaml");
+    JsonNode endpointObject = deploymentSpec.get("endpoints").get("/bmicalc");
+    Executor executor = adapter.activate(URI.create("artifact-list-v1.0/"), "", "", "", "", endpointObject);
+    Object helloResult = executor.execute("{\"height\":2, \"weight\":80}");
+    assertEquals("20.0", helloResult);
+  }
+
+  @Test
+  public void testActivatesObjectWithArrayWithMultipleElementsAndGetsExecutor() throws IOException {
+    JsonNode deploymentSpec = getDeploymentSpec("artifact-list-v2.0/deployment.yaml");
+    JsonNode endpointObject = deploymentSpec.get("endpoints").get("/bmicalc");
+    Executor executor = adapter.activate(URI.create("artifact-list-v2.0/"), "", "", "", "", endpointObject);
+    Object helloResult = executor.execute("{\"height\":2, \"weight\":80}");
+    assertEquals("20.0", helloResult);
+  }
+
+  @Test
+  public void testActivatesObjectWithArrayWithMultipleElementsNoEntryAndGetsExecutor() throws IOException {
+    JsonNode deploymentSpec = getDeploymentSpec("artifact-list-v3.0/deployment.yaml");
+    JsonNode endpointObject = deploymentSpec.get("endpoints").get("/bmicalc");
+    Executor executor = adapter.activate(URI.create("artifact-list-v3.0/"), "", "", "", "", endpointObject);
+    Object helloResult = executor.execute("{\"height\":2, \"weight\":80}");
+    assertEquals("20.0", helloResult);
+  }
+
+  @Test
   public void testActivatesBundledJSObjectAndGetsExecutor() throws IOException {
     JsonNode deploymentSpec = getDeploymentSpec("hello-world-v1.3/deploymentSpec.yaml");
     JsonNode endpointObject = deploymentSpec.get("endpoints").get("/welcome");

--- a/src/test/resources/artifact-list-v1.0/bmi.js
+++ b/src/test/resources/artifact-list-v1.0/bmi.js
@@ -1,0 +1,6 @@
+function bmicalc(inputs){
+  height = inputs.height;
+  weight = inputs.weight;
+  return Number.parseFloat(weight/Math.pow(height, 2)).toFixed(1);
+}
+

--- a/src/test/resources/artifact-list-v1.0/deployment.yaml
+++ b/src/test/resources/artifact-list-v1.0/deployment.yaml
@@ -1,0 +1,6 @@
+endpoints:
+  /bmicalc:
+    artifact:
+      -  'bmi.js'
+    adapter: 'JAVASCRIPT'
+    function: 'bmicalc'

--- a/src/test/resources/artifact-list-v1.0/metadata.json
+++ b/src/test/resources/artifact-list-v1.0/metadata.json
@@ -1,0 +1,13 @@
+{
+  "@id": "artifact/list/v1.0",
+  "@type":"koio:KnowledgeObject",
+  "identifier": "ark:/artifact/list/v1.0",
+  "version":"v1.0",
+  "title": "Implementation of BMI Calculator to be activated in the remote NodeJS runtime",
+  "description":"Calculates BMI",
+  "keywords":["GraalJS","bmi", "calculator"],
+  "hasServiceSpecification": "service.yaml",
+  "hasDeploymentSpecification": "deployment.yaml",
+  "hasPayload": "bmi.js",
+  "@context" : ["http://kgrid.org/koio/contexts/knowledgeobject.jsonld" ]
+}

--- a/src/test/resources/artifact-list-v1.0/service.yaml
+++ b/src/test/resources/artifact-list-v1.0/service.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.0
+info:
+  version: 1.0
+  title: BMI Calc
+  description: Calculates BMI
+  license:
+    name: GNU General Public License v3 (GPL-3)
+    url: >-
+      https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext
+  contact:
+    name: KGrid Team
+    email: kgrid-developers@umich.edu
+    url: 'http://kgrid.org'
+servers:
+  - url: /artifact/list/1.0
+    description: BMI Calculator
+tags:
+  - name: BMI Calculator Endpoint
+    description: BMI Endpoints
+paths:
+  /bmicalc:
+    post:
+      tags:
+        - KO Endpoints
+      description: BMI Calculator.
+      operationId: bmi
+      requestBody:
+        description: inputs
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/measures'
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bmiOutput'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+ components:
+  schemas:
+    measures:
+      required:
+        - height
+        - weight
+      properties:
+        height:
+          type: number
+          x-kgrid-unit: m
+          example: 1.7
+        weight:
+          type: number
+          x-kgrid-unit: kg
+          example: 70.2
+    bmiOutput:
+      required:
+        - result
+      properties:
+        result:
+          type: number
+          example: 25
+    error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/src/test/resources/artifact-list-v2.0/bmi.js
+++ b/src/test/resources/artifact-list-v2.0/bmi.js
@@ -1,0 +1,6 @@
+function bmicalc(inputs){
+  height = inputs.height;
+  weight = inputs.weight;
+  return Number.parseFloat(weight/Math.pow(height, 2)).toFixed(1);
+}
+

--- a/src/test/resources/artifact-list-v2.0/deployment.yaml
+++ b/src/test/resources/artifact-list-v2.0/deployment.yaml
@@ -1,0 +1,8 @@
+endpoints:
+  /bmicalc:
+    artifact:
+      -  'bmi.js'
+      -  'extra-scripts.js'
+    adapter: 'JAVASCRIPT'
+    function: 'bmicalc'
+    entry: 'bmi.js'

--- a/src/test/resources/artifact-list-v2.0/metadata.json
+++ b/src/test/resources/artifact-list-v2.0/metadata.json
@@ -1,0 +1,13 @@
+{
+  "@id": "artifact/list/v2.0",
+  "@type":"koio:KnowledgeObject",
+  "identifier": "ark:/artifact/list/v2.0",
+  "version":"v2.0",
+  "title": "Implementation of BMI Calculator to be activated in the remote NodeJS runtime",
+  "description":"Calculates BMI",
+  "keywords":["GraalJS","bmi", "calculator"],
+  "hasServiceSpecification": "service.yaml",
+  "hasDeploymentSpecification": "deployment.yaml",
+  "hasPayload": "bmi.js",
+  "@context" : ["http://kgrid.org/koio/contexts/knowledgeobject.jsonld" ]
+}

--- a/src/test/resources/artifact-list-v2.0/service.yaml
+++ b/src/test/resources/artifact-list-v2.0/service.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.0
+info:
+  version: 1.0
+  title: BMI Calc
+  description: Calculates BMI
+  license:
+    name: GNU General Public License v3 (GPL-3)
+    url: >-
+      https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext
+  contact:
+    name: KGrid Team
+    email: kgrid-developers@umich.edu
+    url: 'http://kgrid.org'
+servers:
+  - url: /artifact/list/1.0
+    description: BMI Calculator
+tags:
+  - name: BMI Calculator Endpoint
+    description: BMI Endpoints
+paths:
+  /bmicalc:
+    post:
+      tags:
+        - KO Endpoints
+      description: BMI Calculator.
+      operationId: bmi
+      requestBody:
+        description: inputs
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/measures'
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bmiOutput'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+ components:
+  schemas:
+    measures:
+      required:
+        - height
+        - weight
+      properties:
+        height:
+          type: number
+          x-kgrid-unit: m
+          example: 1.7
+        weight:
+          type: number
+          x-kgrid-unit: kg
+          example: 70.2
+    bmiOutput:
+      required:
+        - result
+      properties:
+        result:
+          type: number
+          example: 25
+    error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/src/test/resources/artifact-list-v3.0/bmi.js
+++ b/src/test/resources/artifact-list-v3.0/bmi.js
@@ -1,0 +1,6 @@
+function bmicalc(inputs){
+  height = inputs.height;
+  weight = inputs.weight;
+  return Number.parseFloat(weight/Math.pow(height, 2)).toFixed(1);
+}
+

--- a/src/test/resources/artifact-list-v3.0/deployment.yaml
+++ b/src/test/resources/artifact-list-v3.0/deployment.yaml
@@ -1,0 +1,7 @@
+endpoints:
+  /bmicalc:
+    artifact:
+      -  'bmi.js'
+      -  'extra-scripts.js'
+    adapter: 'JAVASCRIPT'
+    function: 'bmicalc'

--- a/src/test/resources/artifact-list-v3.0/metadata.json
+++ b/src/test/resources/artifact-list-v3.0/metadata.json
@@ -1,0 +1,13 @@
+{
+  "@id": "artifact/list/v3.0",
+  "@type":"koio:KnowledgeObject",
+  "identifier": "ark:/artifact/list/v3.0",
+  "version":"v3.0",
+  "title": "Implementation of BMI Calculator to be activated in the remote NodeJS runtime",
+  "description":"Calculates BMI",
+  "keywords":["GraalJS","bmi", "calculator"],
+  "hasServiceSpecification": "service.yaml",
+  "hasDeploymentSpecification": "deployment.yaml",
+  "hasPayload": "bmi.js",
+  "@context" : ["http://kgrid.org/koio/contexts/knowledgeobject.jsonld" ]
+}

--- a/src/test/resources/artifact-list-v3.0/service.yaml
+++ b/src/test/resources/artifact-list-v3.0/service.yaml
@@ -1,0 +1,78 @@
+openapi: 3.0.0
+info:
+  version: 1.0
+  title: BMI Calc
+  description: Calculates BMI
+  license:
+    name: GNU General Public License v3 (GPL-3)
+    url: >-
+      https://tldrlegal.com/license/gnu-general-public-license-v3-(gpl-3)#fulltext
+  contact:
+    name: KGrid Team
+    email: kgrid-developers@umich.edu
+    url: 'http://kgrid.org'
+servers:
+  - url: /artifact/list/1.0
+    description: BMI Calculator
+tags:
+  - name: BMI Calculator Endpoint
+    description: BMI Endpoints
+paths:
+  /bmicalc:
+    post:
+      tags:
+        - KO Endpoints
+      description: BMI Calculator.
+      operationId: bmi
+      requestBody:
+        description: inputs
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/measures'
+      responses:
+        '200':
+          description: response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/bmiOutput'
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/error'
+ components:
+  schemas:
+    measures:
+      required:
+        - height
+        - weight
+      properties:
+        height:
+          type: number
+          x-kgrid-unit: m
+          example: 1.7
+        weight:
+          type: number
+          x-kgrid-unit: kg
+          example: 70.2
+    bmiOutput:
+      required:
+        - result
+      properties:
+        result:
+          type: number
+          example: 25
+    error:
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string


### PR DESCRIPTION
Augmented artifact handling in the activate method to handle arrays: It uses the first artifact in if there's only one or if there's no entry specifying which artifact to use, otherwise it uses the artifact specified in the entry field. It still handles single artifact strings the same as before.